### PR TITLE
Update dependency-check to fix NullPointerException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
                <!-- Consider combining with Red Hat Victims and OSS Index. More info on Victims vs. Dependency-check: https://bugzilla.redhat.com/show_bug.cgi?id=1388712 -->
                <groupId>org.owasp</groupId>
                <artifactId>dependency-check-maven</artifactId>
-               <version>6.0.3</version>
+               <version>6.1.6</version>
             </plugin>
             <plugin>
                <groupId>org.jvnet.jaxb2.maven2</groupId>


### PR DESCRIPTION
Update dependency-check to version 6.1.6 to fix NullPointerException. See details: https://github.com/jeremylong/DependencyCheck/issues/3360